### PR TITLE
ci: fix build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v30
       - uses: DeterminateSystems/magic-nix-cache-action@main
-      - run: nix shell --command bash -c "echo hi"
+      - run: nix develop . --command bash -c "echo hi"
 
   nix_build_tests_flake:
     name: "Nix Flake: Build all Guest Tests"


### PR DESCRIPTION
`nix shell` by default adds `.#default` to the PATH. But actually, here, I want to add the whole development shell into the scope. Therefore, we have to use `nix develop`